### PR TITLE
add logic to open dashboard app without top nav

### DIFF
--- a/test/functional/page_objects/header_page.js
+++ b/test/functional/page_objects/header_page.js
@@ -62,8 +62,13 @@ export function HeaderPageProvider({ getService, getPageObjects }) {
     async clickDashboard() {
       log.debug('click Dashboard tab');
       await this.clickSelector('a[href*=\'dashboard\']');
-      await PageObjects.common.waitForTopNavToBeVisible();
-      await this.confirmTopNavTextContains('dashboard');
+      await retry.try(async () => {
+        const isNavVisible = await testSubjects.exists('top-nav');
+        const isLandingPageVisible = await testSubjects.exists('dashboardLandingPage');
+        if (!isNavVisible && !isLandingPageVisible) {
+          throw new Error('Dashboard application not loaded yet');
+        }
+      });
       await this.awaitGlobalLoadingIndicatorHidden();
     }
 


### PR DESCRIPTION
this will fix the latest functional test error.

the tests call `clickDashboard` to open the dashboard app and that method was expecting the top nav to be there. This PR just looks for either the top nav or the dashboard landing page